### PR TITLE
Adding co describe for any failed degraded operators 

### DIFF
--- a/cerberus/inspect/inspect.py
+++ b/cerberus/inspect/inspect.py
@@ -1,5 +1,6 @@
 import os
 import logging
+
 import cerberus.invoke.command as runcommand
 
 
@@ -9,6 +10,7 @@ def delete_inspect_directory():
     if os.path.isdir("inspect_data/"):
         logging.info("Deleting existing inspect_data directory")
         runcommand.invoke("rm -R inspect_data")
+    runcommand.invoke("mkdir inspect_data")
 
 
 def inspect_component(namespace):
@@ -16,5 +18,14 @@ def inspect_component(namespace):
     if os.path.isdir(dir_name):
         runcommand.invoke("rm -R " + dir_name)
         logging.info("Deleted existing %s directory" % (dir_name))
-    command_out = runcommand.invoke("oc adm inspect ns/" + namespace + " --dest" "-dir=" + dir_name + " | tr -d '\n'")
-    logging.info(command_out)
+    runcommand.invoke("oc adm inspect ns/" + namespace + " --dest-dir=" + dir_name + " | tr -d '\n'")
+    logging.info("Inspecting namespace %s into %s" % (namespace, dir_name))
+
+
+def inspect_operator(operator):
+    dir_name = "inspect_data/" + operator + "-logs.out"
+    if os.path.isdir(dir_name):
+        runcommand.invoke("rm -R " + dir_name)
+        logging.info("Deleted existing %s directory" % (dir_name))
+    runcommand.invoke("oc adm inspect clusteroperator/" + operator + " --dest-dir=" + dir_name)
+    logging.info("Inspecting cluster operator %s into %s" % (operator, dir_name))

--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -300,10 +300,11 @@ def main(cfg):
                     logging.info("%s\n" % (failed_nodes))
                     dbcli.insert(datetime.now(), time.time(), 1, "not ready", failed_nodes, "node")
 
-                if not watch_cluster_operators_status:
+                if not watch_cluster_operators_status and distribution == "openshift" and watch_cluster_operators:
                     logging.info("Iteration %s: Failed operators" % (iteration))
                     logging.info("%s\n" % (failed_operators))
                     dbcli.insert(datetime.now(), time.time(), 1, "degraded", failed_operators, "cluster operator")
+                    pool.map(inspect.inspect_operator, failed_operators)
 
                 if not server_status:
                     logging.info(


### PR DESCRIPTION
### Description
When any of the cluster operators are degraded and the inspect flag is set to True, adding in a kubectl describe of the operator to be able to open bugs 

### Fixes
https://github.com/cloud-bulldozer/cerberus/issues/146