### PR TITLE
Urllib3 Set Version, Updates for CI (jenkins) 

### DIFF
--- a/cerberus/kubernetes/client.py
+++ b/cerberus/kubernetes/client.py
@@ -8,9 +8,8 @@ from collections import defaultdict
 from kubernetes import client, config
 import cerberus.invoke.command as runcommand
 from kubernetes.client.rest import ApiException
-from urllib3.exceptions import InsecureRequestWarning
 
-requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+requests.packages.urllib3.disable_warnings()
 
 pods_tracker = defaultdict(dict)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ configparser
 slackclient
 pyfiglet
 prometheus_api_client
+urllib3==1.23


### PR DESCRIPTION
### Description
During cerberus used in a CI (jenkins), the jenkins agent is no longer able to connect after usage of the repeat() for pool.starmap. I propose taking it out. I'm not sure what the original usage was 

There are also lots of urllib3 warnings, putting urllib3 to a specific verison to cut down on those


Error would always look something like this
```
04-20 15:40:48.826  
04-20 15:40:49.423  2022-04-20 19:40:49,392 [INFO] []
04-20 15:40:49.423  
04-20 15:40:49.423  2022-04-20 19:40:49,392 [INFO] Sleeping for the specified duration: 3
04-20 15:40:49.423  
04-20 15:41:00.494  Cannot contact psi-ocp-c1-cucushift-oc411-standard-slave-tf4w9: hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@67a7d006:JNLP4-connect connection from 172.31.0.1/172.31.0.1:54414": Remote call on JNLP4-connect connection from 172.31.0.1/172.31.0.1:54414 failed. The channel is closing down or has closed down
04-20 15:41:12.660  Could not connect to psi-ocp-c1-cucushift-oc411-standard-slave-tf4w9 to send interrupt signal to process
```