### PR TITLE
Krkn hub link in workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Build Kraken-hub Image
       uses: convictional/trigger-workflow-and-wait@v1.5.0
       with:
-        owner: cloud-bulldozer
-        repo: kraken-hub
+        owner: chaos-kubox
+        repo: krkn-hub
         github_token: ${{ secrets.G_ACCESS_TOKEN }}
         workflow_file_name: docker-image.yml
         trigger_workflow: true


### PR DESCRIPTION
### Description
Missed similar link to krkn-hub repo in github workflow 


### Fixes
https://github.com/cloud-bulldozer/cerberus/runs/6163504717?check_suite_focus=true
