### PR TITLE
Docs and image build fixes

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -13,8 +13,8 @@ COPY --from=origintests /usr/bin/oc /usr/bin/oc
 COPY --from=origintests /usr/bin/kubectl /usr/bin/kubectl
 
 # Install dependencies
-RUN yum install -y git python36 python3-pip gcc python3-devel && \
-git clone https://github.com/openshift-scale/cerberus /root/cerberus && \
+RUN yum install -y git python36 python3-pip gcc python3-devel zlib-devel libjpeg-devel && \
+git clone https://github.com/chaos-kubox/cerberus /root/cerberus && \
 mkdir -p /root/.kube && cd /root/cerberus && \
 pip3 install -r requirements.txt
 

--- a/containers/build_own_image-README.md
+++ b/containers/build_own_image-README.md
@@ -1,13 +1,13 @@
 # Building your own Cerberus image
 
-1. Git clone the Cerberus repository using `git clone https://github.com/cloud-bulldozer/cerberus.git`.
+1. Git clone the Cerberus repository using `git clone https://github.com/chaos-kubox/cerberus.git`.
 2. Modify the python code and yaml files to address your needs.
 3. Execute `podman build -t <new_image_name>:latest .` in the containers directory within cerberus to build an image from a Dockerfile.
 4. Execute `podman run --detach --name <container_name> <new_image_name>:latest` to start a container based on your new image.
 
 # Building the Cerberus image on IBM Power (ppc64le arch)
 
-1. Git clone the Cerberus repository using `git clone https://github.com/cloud-bulldozer/cerberus.git` on an IBM Power Systems server.
+1. Git clone the Cerberus repository using `git clone https://github.com/chaos-kubox/cerberus.git` on an IBM Power Systems server.
 2. Modify the python code and yaml files to address your needs.
 3. Execute `podman build -t <new_image_name>:latest -f Dockerfile-ppc64le` in the containers directory within cerberus to build an image from the Dockerfile for Power.
 4. Execute `podman run --detach --name <container_name> <new_image_name>:latest` to start a container based on your new image.


### PR DESCRIPTION
cerberus image build fails on a couple of dependencies needed for pillow python libraries.
Also fixing instruction docs to refer to the correct repo.