### PR TITLE
adding new way to get token

### DIFF
--- a/cerberus/prometheus/client.py
+++ b/cerberus/prometheus/client.py
@@ -15,7 +15,10 @@ def initialize_prom_client(distribution, prometheus_url, prometheus_bearer_token
         )
         prometheus_url = "https://" + url
     if distribution == "openshift" and not prometheus_bearer_token:
-        prometheus_bearer_token = runcommand.invoke("oc -n openshift-monitoring " "sa get-token prometheus-k8s")
+        prometheus_bearer_token = runcommand.invoke(
+            "oc -n openshift-monitoring sa get-token prometheus-k8s "
+            "|| oc create token -n openshift-monitoring prometheus-k8s"
+        )
     if prometheus_url and prometheus_bearer_token:
         bearer = "Bearer " + prometheus_bearer_token
         headers = {"Authorization": bearer}


### PR DESCRIPTION
 The prometheus token is no longer set by default so we now have to create our own (this is for oc4.11)

Adding an OR statement to not break previous versions 
 
 % oc -n openshift-monitoring sa get-token prometheus-k8s 
Command "get-token" is deprecated, and will be removed in the future version. Use oc create token instead.
error: could not find a service account token for service account "prometheus-k8s"